### PR TITLE
CMake updates.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,10 @@ add_executable(test_utf8 main.cpp)
 target_compile_options(test_utf8 PUBLIC /utf-8)
 
 if(MSVC)
-		ADD_CUSTOM_COMMAND(
-			TARGET test_utf8
-			POST_BUILD
-			DEPENDS 
-			COMMAND mt.exe -manifest manifest.xml -inputresource:\"$<TARGET_FILE:test_utf8>\"\;\#1 -updateresource:\"$<TARGET_FILE:test_utf8>\"\;\#1
-		)
-	ENDIF()
+	ADD_CUSTOM_COMMAND(
+		TARGET test_utf8
+		POST_BUILD
+		DEPENDS
+		COMMAND mt.exe -manifest "${CMAKE_SOURCE_DIR}/manifest.xml" -inputresource:"$<TARGET_FILE:test_utf8>"\;\#1 -updateresource:"$<TARGET_FILE:test_utf8>"\;\#1
+	)
 ENDIF(MSVC)


### PR DESCRIPTION
This change corrects CMakeLists.txt to remove an extraneous endif()
and add a path to manifest.xml so that it is found when the CMake
build directory differs from the source directory.